### PR TITLE
一旦実装まで。nodesの情報は表示されているが、ツリー表記はされていない状態

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@ionic-native/status-bar": "5.0.0-beta.15",
         "@ionic/angular": "^5.1.1",
         "@ionic/storage": "^2.1.3",
+        "angular-tree-component": "^8.5.2",
         "cordova-android": "^8.1.0",
         "cordova-ios": "^5.1.1",
         "cordova-plugin-device": "^2.0.3",
@@ -400,6 +401,7 @@
       "version": "8.2.14",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.14.tgz",
       "integrity": "sha512-ABZO4E7eeFA1QyJ2trDezxeQM5ZFa1dXw1Mpl/+1vuXDKNjJgNyWYwKp/NwRkLmrsuV0yv4UDCDe4kJOGbPKnw==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
       }
@@ -3607,6 +3609,25 @@
       "integrity": "sha512-/GWUAqa2OJNlDF5VGSe3SR1QMHEPXxx54Ur56r0qQC0H9FlBr7kyBF2SgVEhzFCPbrW4UcYgVuWrq/2Ty3QvXg==",
       "dependencies": {
         "semver": "^5.4.1"
+      }
+    },
+    "node_modules/angular-tree-component": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/angular-tree-component/-/angular-tree-component-8.5.2.tgz",
+      "integrity": "sha512-3NwMB+vLq1+WHz2UVgsZA73E1LmIIWJlrrasCKXbLJ3S7NmY9O/wKcolji3Vp2W//5KQ33RXu1jiPXCOQdRzVA==",
+      "deprecated": "Library moved to @circlon/angular-tree-component",
+      "hasInstallScript": true,
+      "dependencies": {
+        "lodash": "^4.17.11",
+        "mobx": "^5.14.2",
+        "mobx-angular": "3.0.3",
+        "opencollective-postinstall": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "core-js": "^2.4.1"
       }
     },
     "node_modules/ansi": {
@@ -9234,8 +9255,7 @@
     "node_modules/lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-      "dev": true
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -9896,6 +9916,24 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "node_modules/mobx": {
+      "version": "5.15.7",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.7.tgz",
+      "integrity": "sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-angular": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mobx-angular/-/mobx-angular-3.0.3.tgz",
+      "integrity": "sha512-mZuuose70V+Sd0hMWDElpRe3mA6GhYjSQN3mHzqk2XWXRJ+eWQa/f3Lqhw+Me/Xd2etWsGR1hnRa1BfQ2ZDtpw==",
+      "peerDependencies": {
+        "@angular/core": ">=2.3.0",
+        "mobx": ">=2"
+      }
+    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -10455,6 +10493,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/opn": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@ionic-native/status-bar": "5.0.0-beta.15",
     "@ionic/angular": "^5.1.1",
     "@ionic/storage": "^2.1.3",
+    "angular-tree-component": "^8.5.2",
     "cordova-android": "^8.1.0",
     "cordova-ios": "^5.1.1",
     "cordova-plugin-device": "^2.0.3",

--- a/src/app/pages/helloWorld/helloWorld.html
+++ b/src/app/pages/helloWorld/helloWorld.html
@@ -8,5 +8,5 @@
 </ion-header>
 
 <ion-content>
-
+  <tree-root [nodes]="nodes" [options]="options"></tree-root>
 </ion-content>

--- a/src/app/pages/helloWorld/helloWorld.module.ts
+++ b/src/app/pages/helloWorld/helloWorld.module.ts
@@ -5,13 +5,15 @@ import { IonicModule } from '@ionic/angular';
 
 import { HelloWorldPage } from './helloWorld';
 import { HelloWorldPageRoutingModule } from './helloWorld-routing.module';
+import { TreeModule } from 'angular-tree-component';
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
-    HelloWorldPageRoutingModule
+    HelloWorldPageRoutingModule,
+    TreeModule.forRoot()
   ],
   declarations: [
     HelloWorldPage,

--- a/src/app/pages/helloWorld/helloWorld.scss
+++ b/src/app/pages/helloWorld/helloWorld.scss
@@ -1,1 +1,1 @@
-
+@import '~angular-tree-component/dist/angular-tree-component.css';

--- a/src/app/pages/helloWorld/helloWorld.ts
+++ b/src/app/pages/helloWorld/helloWorld.ts
@@ -18,4 +18,30 @@ export class HelloWorldPage {
     public router: Router,
     public userData: UserData
   ) { }
+
+  nodes = [
+    {
+      id: 1,
+      name: 'root1',
+      children: [
+        { id: 2, name: 'child1' },
+        { id: 3, name: 'child2' }
+      ]
+    },
+    {
+      id: 4,
+      name: 'root2',
+      children: [
+        { id: 5, name: 'child2.1' },
+        {
+          id: 6,
+          name: 'child2.2',
+          children: [
+            { id: 7, name: 'subsub' }
+          ]
+        }
+      ]
+    }
+  ];
+  options = {};
 }


### PR DESCRIPTION
## 変更点
- angular-tree-componentのインストール
  ※インストールの際、バージョンの競合が発生したため、```--legacy-peer-deps```オプションをつけてインストール
- ツリーコンポーネントの表示
 
## その他
```nodes```の内容がツリー表記されておらず、
1層目の内容しか表示されていません。
原因は現在調査中ですが、typescriptのバージョンが4.9.4であることが考えられます。
typescriptの3.5.3をインストールして、正しく表示されるか、確認します。

## スクリーンショット
![image](https://user-images.githubusercontent.com/48784423/209522574-d1bb2e5c-f294-464f-ab4e-736ae53649cf.png)

## 参考にしたページ
https://angular2-tree.readme.io/v8.0.0/docs